### PR TITLE
[fix] Downgrade ember-cli to 3.14.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2307,7 +2307,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -5361,7 +5361,7 @@
     },
     "broccoli-clean-css": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/broccoli-clean-css/-/broccoli-clean-css-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/broccoli-clean-css/-/broccoli-clean-css-1.1.0.tgz",
       "integrity": "sha1-nbFD2a9+CuecJuOsWpuy1yDqGfo=",
       "dev": true,
       "requires": {
@@ -7207,7 +7207,7 @@
     },
     "clean-css-promise": {
       "version": "0.1.1",
-      "resolved": "http://registry.npmjs.org/clean-css-promise/-/clean-css-promise-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/clean-css-promise/-/clean-css-promise-0.1.1.tgz",
       "integrity": "sha1-Q/PSyN/LK/BxSBJSzZt2QzwI7ss=",
       "dev": true,
       "requires": {
@@ -7306,7 +7306,7 @@
     },
     "colors": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
       "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
       "dev": true
     },
@@ -8526,12 +8526,12 @@
       }
     },
     "ember-cli": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/ember-cli/-/ember-cli-3.15.1.tgz",
-      "integrity": "sha512-KBL6ylTpYD6k0B2iHMvdgNnbKCdFnOHzruosQqTmbHpyJljVE1sLsTP8ErROH/PnbFzc1vZg1qQcf6tHRvyTrw==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/ember-cli/-/ember-cli-3.14.0.tgz",
+      "integrity": "sha512-ZZEArSq8ynU6FbVAQnS2Nbx2yr73EgYsAngOHKOGoJwa6YEs3LFh4lHjYsxF26Bt245lH83WnehRcdlLssNF3w==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.7.2",
+        "@babel/core": "^7.6.2",
         "@babel/plugin-transform-modules-amd": "^7.5.0",
         "amd-name-resolver": "^1.3.1",
         "babel-plugin-module-resolver": "^3.2.0",
@@ -8565,6 +8565,7 @@
         "core-object": "^3.1.5",
         "dag-map": "^2.0.2",
         "diff": "^4.0.1",
+        "ember-cli-broccoli-sane-watcher": "^3.0.0",
         "ember-cli-is-package-missing": "^1.0.0",
         "ember-cli-lodash-subset": "^2.0.1",
         "ember-cli-normalize-entity-name": "^1.0.0",
@@ -8602,7 +8603,7 @@
         "nopt": "^3.0.6",
         "npm-package-arg": "^6.1.1",
         "p-defer": "^3.0.0",
-        "portfinder": "^1.0.25",
+        "portfinder": "^1.0.23",
         "promise-map-series": "^0.2.3",
         "promise.prototype.finally": "^3.1.1",
         "quick-temp": "^0.1.8",
@@ -8612,7 +8613,7 @@
         "sane": "^4.1.0",
         "semver": "^6.3.0",
         "silent-error": "^1.1.1",
-        "sort-package-json": "^1.23.1",
+        "sort-package-json": "^1.22.1",
         "symlink-or-copy": "^1.2.0",
         "temp": "0.9.0",
         "testem": "^2.17.0",
@@ -9278,6 +9279,19 @@
       "resolved": "https://registry.npmjs.org/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.0.tgz",
       "integrity": "sha512-Zr4my8Xn+CzO0gIuFNXji0eTRml5AxZUTDQz/wsNJ5AJAtyFWCY4QtKdoELNNbiCVGt1lq5yLiwTm4scGKu6xA==",
       "dev": true
+    },
+    "ember-cli-broccoli-sane-watcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-broccoli-sane-watcher/-/ember-cli-broccoli-sane-watcher-3.0.0.tgz",
+      "integrity": "sha512-sLn+wy6FJpGMHtSwAGUjQK3nJFvw2b6H8bR2EgMIXxkUI3DYFLi6Xnyxm02XlMTcfTxF10yHFhHJe0O+PcJM7A==",
+      "dev": true,
+      "requires": {
+        "broccoli-slow-trees": "^3.0.1",
+        "heimdalljs": "^0.2.1",
+        "heimdalljs-logger": "^0.1.7",
+        "rsvp": "^3.0.18",
+        "sane": "^4.0.0"
+      }
     },
     "ember-cli-code-coverage": {
       "version": "0.4.2",
@@ -11673,7 +11687,7 @@
     },
     "engine.io-client": {
       "version": "3.4.0",
-      "resolved": "http://registry.npmjs.org/engine.io-client/-/engine.io-client-3.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.4.0.tgz",
       "integrity": "sha512-a4J5QO2k99CM2a0b12IznnyQndoEvtA4UAldhGzKqnHf42I3Qs2W5SPnDvatZRcMaNZs4IevVicBPayxYt6FwA==",
       "dev": true,
       "requires": {
@@ -12712,7 +12726,7 @@
         },
         "http-errors": {
           "version": "1.7.2",
-          "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
           "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
           "dev": true,
           "requires": {
@@ -15679,7 +15693,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -16000,7 +16014,7 @@
     },
     "is-obj": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
       "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
       "dev": true
     },
@@ -21304,7 +21318,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
@@ -21787,7 +21801,7 @@
       "dependencies": {
         "http-errors": {
           "version": "1.7.3",
-          "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
           "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
           "dev": true,
           "requires": {
@@ -22146,7 +22160,7 @@
         },
         "socket.io-parser": {
           "version": "3.3.0",
-          "resolved": "http://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.0.tgz",
           "integrity": "sha512-hczmV6bDgdaEbVqhAeVMM/jfUfzuEZHsQg6eOmLgJht6G3mPKMxYm75w2+qhAQZ+4X+1+ATZ+QFKeOZD5riHng==",
           "dev": true,
           "requires": {
@@ -22176,7 +22190,7 @@
     },
     "socket.io-parser": {
       "version": "3.4.0",
-      "resolved": "http://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.4.0.tgz",
       "integrity": "sha512-/G/VOI+3DBp0+DJKW4KesGnQkQPFmUCbA/oO2QGT6CWxU7hLGWqU3tyuzeSK/dqcyeHsQg1vTe9jiZI8GU9SCQ==",
       "dev": true,
       "requires": {
@@ -23034,7 +23048,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "3.4.0",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
           "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "coveralls": "3.0.9",
     "ember-ajax": "5.0.0",
     "ember-changeset-validations": "2.2.1",
-    "ember-cli": "3.15.1",
+    "ember-cli": "3.14.0",
     "ember-cli-app-version": "3.2.0",
     "ember-cli-babel": "7.13.2",
     "ember-cli-code-coverage": "0.4.2",


### PR DESCRIPTION
To fix the following error when running in production mode:
```
WatcherAdapter's first argument must be an array of SourceNodeWrapper nodes
```